### PR TITLE
query 方法添加默认值all，表示不过滤。

### DIFF
--- a/src/app/_shared/api/threads/index.ts
+++ b/src/app/_shared/api/threads/index.ts
@@ -27,7 +27,7 @@ const items: Thread[] = [
 ];
 @Injectable()
 export class ThreadApi {
-  query(filter: string): Observable<Thread> {
+  query(filter: string = 'all'): Observable<Thread> {
     return Observable.from(items)
       .filter((item: Thread)=> {
         switch (filter) {


### PR DESCRIPTION
在调用该方法时，如果不传参数，则会自动设置为'all'。
