### PR TITLE
[styles] new set of font copied from jianshu

### DIFF
--- a/src/main.scss
+++ b/src/main.scss
@@ -3,3 +3,7 @@
 @import "./app/_shared/styles/material";
 @import "./app/_shared/styles/bootstrap-extends";
 @import "./app/_shared/styles/app";
+
+* {
+  font-family: -apple-system, "Helvetica Neue", Arial, "PingFang SC", "lucida grande", "lucida sans unicode", lucida, helvetica, "Hiragino Sans GB", "Microsoft YaHei", "WenQuanYi Micro Hei", sans-serif;
+}


### PR DESCRIPTION
wx.angular.cn 在 windows 版的 chrome 里字体粗细不一（edge 里显示正常，手机 chrome 里也正常）。从 jianshu.com 上拷贝了一组字体。  
会有版权问题吗？拷贝内容如下：
`font-family: -apple-system, "Helvetica Neue", Arial, "PingFang SC", "lucida grande", "lucida sans unicode", lucida, helvetica, "Hiragino Sans GB", "Microsoft YaHei", "WenQuanYi Micro Hei", sans-serif`  

before: ![before](https://raw.githubusercontent.com/rxjs-space/files/master/before-in-chrome-windows.png)  
after: ![after](https://raw.githubusercontent.com/rxjs-space/files/master/after-in-chrome-windows.png)