### PR TITLE
[feature] locate author by name as well as by id

### DIFF
--- a/src/app/_shared/api/authors/index.ts
+++ b/src/app/_shared/api/authors/index.ts
@@ -122,6 +122,21 @@ export class AuthorApi {
       }
     }
 
+    // \user-ui\src\app\_shared\api\articles\index.ts
+    // 这个文章列表里，authors 一栏指向作者的 id，不是作者的 name
+    // 如果在 authors 里填写 name，使用上面的 for loop by id 是找不到的，在文章页面点击作者名字就会 404，
+    // 所以还要 for loop by name 再找一遍
+    // 这样 `library/author/dapao` 和 `library/author/大炮` 都能找到作者页面
+    if (index === null) {
+      console.log('by name');
+      for (let i = 0; i < items.length; i++) {
+        if (items[i].name === params.id) {
+          index = i;  // 找到了，index改成i，找不到，index还是null
+          break;
+        }
+      }
+    }
+
     let spectreAuthor: Author = {
       id: 'spectre',
       name: '我叫404',

--- a/src/app/_shared/api/authors/index.ts
+++ b/src/app/_shared/api/authors/index.ts
@@ -126,9 +126,8 @@ export class AuthorApi {
     // 这个文章列表里，authors 一栏指向作者的 id，不是作者的 name
     // 如果在 authors 里填写 name，使用上面的 for loop by id 是找不到的，在文章页面点击作者名字就会 404，
     // 所以还要 for loop by name 再找一遍
-    // 这样 `library/author/dapao` 和 `library/author/大炮` 都能找到作者页面
+    // 这样 `library/author/id` 和 `library/author/name` 都能找到作者页面
     if (index === null) {
-      console.log('by name');
       for (let i = 0; i < items.length; i++) {
         if (items[i].name === params.id) {
           index = i;  // 找到了，index改成i，找不到，index还是null


### PR DESCRIPTION
[这篇文章](https://wx.angular.cn/library/article/%E5%A6%82%E4%BD%95%E5%B7%A5%E7%A8%8B%E5%8C%96%E5%BC%80%E5%8F%91%E5%A4%A7%E5%9E%8Bangular2%E9%A1%B9%E7%9B%AE)，作者在源文件 `\user-ui\src\app\_shared\api\articles\index.ts` 里 authors 一栏填的是 '大炮'。`大炮` 是 name，不是 id。但是导向作者页面的 path 要求 param 是 id，不是 name。所以 `https://wx.angular.cn/library/author/大炮` 是找不到到作者页面的。本 commit 解决这个问题，即实现 `https://wx.angular.cn/library/author/name` 和 `https://wx.angular.cn/library/author/id`等效。